### PR TITLE
Added runtimedefault seccompprofile to seccontext.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+ - Defined the use of the RuntimeDefault Seccompprofiles in the pod and container security context.
+
 ## [1.17.2-gs1] - 2022-09-14
 
 ### Changed

--- a/helm/aws-node-termination-handler-app/values.schema.json
+++ b/helm/aws-node-termination-handler-app/values.schema.json
@@ -1,0 +1,520 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object",
+            "properties": {
+                "podAntiAffinity": {
+                    "type": "object",
+                    "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "podAffinityTerm": {
+                                        "type": "object",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "topologyKey": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "weight": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "awsAccessKeyID": {
+            "type": "null"
+        },
+        "awsEndpoint": {
+            "type": "string"
+        },
+        "awsRegion": {
+            "type": "string"
+        },
+        "awsSecretAccessKey": {
+            "type": "null"
+        },
+        "checkASGTagBeforeDraining": {
+            "type": "boolean"
+        },
+        "cordonOnly": {
+            "type": "boolean"
+        },
+        "customLabels": {
+            "type": "object"
+        },
+        "daemonsetAffinity": {
+            "type": "object",
+            "properties": {
+                "nodeAffinity": {
+                    "type": "object",
+                    "properties": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "object",
+                            "properties": {
+                                "nodeSelectorTerms": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "matchExpressions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "key": {
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "type": "string"
+                                                        },
+                                                        "values": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "daemonsetNodeSelector": {
+            "type": "object"
+        },
+        "daemonsetPriorityClassName": {
+            "type": "string"
+        },
+        "daemonsetTolerations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "operator": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "deleteLocalData": {
+            "type": "boolean"
+        },
+        "dnsConfig": {
+            "type": "object"
+        },
+        "dnsPolicy": {
+            "type": "string"
+        },
+        "dryRun": {
+            "type": "boolean"
+        },
+        "emitKubernetesEvents": {
+            "type": "boolean"
+        },
+        "enableProbesServer": {
+            "type": "boolean"
+        },
+        "enablePrometheusServer": {
+            "type": "boolean"
+        },
+        "enableRebalanceDraining": {
+            "type": "boolean"
+        },
+        "enableRebalanceMonitoring": {
+            "type": "boolean"
+        },
+        "enableScheduledEventDraining": {
+            "type": "boolean"
+        },
+        "enableSpotInterruptionDraining": {
+            "type": "boolean"
+        },
+        "enableSqsTerminationDraining": {
+            "type": "boolean"
+        },
+        "excludeFromLoadBalancers": {
+            "type": "boolean"
+        },
+        "extraEnv": {
+            "type": "array"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "ignoreDaemonSets": {
+            "type": "boolean"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "instanceMetadataURL": {
+            "type": "string"
+        },
+        "jsonLogging": {
+            "type": "boolean"
+        },
+        "kubernetesEventsExtraAnnotations": {
+            "type": "string"
+        },
+        "linuxAffinity": {
+            "type": "object"
+        },
+        "linuxDnsPolicy": {
+            "type": "string"
+        },
+        "linuxNodeSelector": {
+            "type": "object"
+        },
+        "linuxPodAnnotations": {
+            "type": "object"
+        },
+        "linuxPodLabels": {
+            "type": "object"
+        },
+        "linuxTolerations": {
+            "type": "array"
+        },
+        "logLevel": {
+            "type": "string"
+        },
+        "managedAsgTag": {
+            "type": "string"
+        },
+        "metadataTries": {
+            "type": "integer"
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "nodeTerminationGracePeriod": {
+            "type": "integer"
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "properties": {
+                "maxUnavailable": {
+                    "type": "integer"
+                }
+            }
+        },
+        "podLabels": {
+            "type": "object"
+        },
+        "podMonitor": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "namespace": {
+                    "type": "null"
+                },
+                "sampleLimit": {
+                    "type": "integer"
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "fsGroup": {
+                    "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "podTerminationGracePeriod": {
+            "type": "integer"
+        },
+        "priorityClassName": {
+            "type": "string"
+        },
+        "probes": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "procUptimeFile": {
+            "type": "string"
+        },
+        "prometheusServerPort": {
+            "type": "integer"
+        },
+        "queueURL": {
+            "type": "string"
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "pspEnabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "replicas": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "number"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "number"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "runAsGroup": {
+                    "type": "integer"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "null"
+                }
+            }
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "namespace": {
+                    "type": "null"
+                },
+                "sampleLimit": {
+                    "type": "integer"
+                }
+            }
+        },
+        "strategy": {
+            "type": "object"
+        },
+        "taintNode": {
+            "type": "boolean"
+        },
+        "targetNodeOs": {
+            "type": "string"
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "null"
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxUnavailable": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "useHostNetwork": {
+            "type": "boolean"
+        },
+        "useProviderId": {
+            "type": "boolean"
+        },
+        "webhookHeaders": {
+            "type": "string"
+        },
+        "webhookProxy": {
+            "type": "string"
+        },
+        "webhookTemplate": {
+            "type": "string"
+        },
+        "webhookTemplateConfigMapKey": {
+            "type": "string"
+        },
+        "webhookTemplateConfigMapName": {
+            "type": "string"
+        },
+        "webhookURL": {
+            "type": "string"
+        },
+        "webhookURLSecretName": {
+            "type": "string"
+        },
+        "windowsAffinity": {
+            "type": "object"
+        },
+        "windowsDnsPolicy": {
+            "type": "string"
+        },
+        "windowsNodeSelector": {
+            "type": "object"
+        },
+        "windowsPodAnnotations": {
+            "type": "object"
+        },
+        "windowsPodLabels": {
+            "type": "object"
+        },
+        "windowsTolerations": {
+            "type": "array"
+        },
+        "workers": {
+            "type": "integer"
+        }
+    }
+}

--- a/helm/aws-node-termination-handler-app/values.yaml
+++ b/helm/aws-node-termination-handler-app/values.yaml
@@ -33,6 +33,8 @@ podAnnotations: {}
 
 podSecurityContext:
   fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -40,6 +42,8 @@ securityContext:
   allowPrivilegeEscalation: false
   runAsUser: 1000
   runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 terminationGracePeriodSeconds:
 


### PR DESCRIPTION
I've modified the container and pod securitycontexts to let this application make use of the runtime/default seccomp profile. During testing this did not seem to interrupt any functionality. Please confirm this if possible. 
This is done in light of:

https://github.com/giantswarm/roadmap/issues/259

Drop a message on slack if you've got questions.