### PR TITLE
Add io.giantswarm.application annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add `io.giantswarm.application.audience: giantswarm` annotation.
+- Migrate chart metadata annotations to `io.giantswarm.application.*` format.
+
 ## [1.23.1] - 2026-02-12
 
 ### Fixed
@@ -47,77 +52,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
 
-## [1.18.0] - 2023-07-13
-
-### Fixed
-
-- Add required values for pss policies.
-
-## [1.17.2-gs2] - 2023-07-05
-
-### Added
-
-- Add Service Monitor.
-
-### Changed
-
- - Defined the use of the RuntimeDefault Seccompprofiles in the pod and container security context.
-
-## [1.17.2-gs1] - 2022-09-14
-
-### Changed
-
-- Bump to upstream version 1.17.2 and related chart template.
-
-## [1.16.5-gs1] - 2022-07-01
-
-### Changed
-
-- Bump to upstream version 1.16.5 and related chart template.
-
-## [0.4.0] - 2022-06-15
-
-### Changed
-
-- Remove `imagePullSecrets`
-
-## [0.3.1] - 2022-04-20
-
-### Changed
-
-- Push to `giantswarm` catalog instead of `control-plane` one.
-
-## [0.3.0] - 2022-04-20
-
-### Changed
-
-- Allow customizing the container image registry domain.
-
-## [0.2.0] - 2022-03-21
-
-### Added
-
-- Add VerticalPodAutoscaler CR.
-
-## [0.1.0] - 2022-02-28
-
-### Added
-
-- First version.
-
 [Unreleased]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.23.1...HEAD
 [1.23.1]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.23.0...v1.23.1
 [1.23.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.20.0...v1.21.0
 [1.20.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.19.0...v1.20.0
-[1.19.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.18.0...v1.19.0
-[1.18.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.17.2-gs2...v1.18.0
-[1.17.2-gs2]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.17.2-gs1...v1.17.2-gs2
-[1.17.2-gs1]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.16.5-gs1...v1.17.2-gs1
-[1.16.5-gs1]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.4.0...v1.16.5-gs1
-[0.4.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.0.0...v0.1.0
+[1.19.0]: https://github.com/giantswarm/aws-node-termination-handler-app/releases/tag/v1.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,77 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
 
+## [1.18.0] - 2023-07-13
+
+### Fixed
+
+- Add required values for pss policies.
+
+## [1.17.2-gs2] - 2023-07-05
+
+### Added
+
+- Add Service Monitor.
+
+### Changed
+
+ - Defined the use of the RuntimeDefault Seccompprofiles in the pod and container security context.
+
+## [1.17.2-gs1] - 2022-09-14
+
+### Changed
+
+- Bump to upstream version 1.17.2 and related chart template.
+
+## [1.16.5-gs1] - 2022-07-01
+
+### Changed
+
+- Bump to upstream version 1.16.5 and related chart template.
+
+## [0.4.0] - 2022-06-15
+
+### Changed
+
+- Remove `imagePullSecrets`
+
+## [0.3.1] - 2022-04-20
+
+### Changed
+
+- Push to `giantswarm` catalog instead of `control-plane` one.
+
+## [0.3.0] - 2022-04-20
+
+### Changed
+
+- Allow customizing the container image registry domain.
+
+## [0.2.0] - 2022-03-21
+
+### Added
+
+- Add VerticalPodAutoscaler CR.
+
+## [0.1.0] - 2022-02-28
+
+### Added
+
+- First version.
+
 [Unreleased]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.23.1...HEAD
 [1.23.1]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.23.0...v1.23.1
 [1.23.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.20.0...v1.21.0
 [1.20.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.19.0...v1.20.0
-[1.19.0]: https://github.com/giantswarm/aws-node-termination-handler-app/releases/tag/v1.19.0
+[1.19.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.18.0...v1.19.0
+[1.18.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.17.2-gs2...v1.18.0
+[1.17.2-gs2]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.17.2-gs1...v1.17.2-gs2
+[1.17.2-gs1]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v1.16.5-gs1...v1.17.2-gs1
+[1.16.5-gs1]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.4.0...v1.16.5-gs1
+[0.4.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/giantswarm/aws-node-termination-handler-app/compare/v0.0.0...v0.1.0

--- a/helm/aws-node-termination-handler/Chart.yaml
+++ b/helm/aws-node-termination-handler/Chart.yaml
@@ -11,3 +11,10 @@ restrictions:
   compatibleProviders: ["aws"]
 annotations:
   application.giantswarm.io/team: "phoenix"
+  io.giantswarm.application.audience: giantswarm
+  io.giantswarm.application.managed: "true"
+  io.giantswarm.application.team: phoenix
+  io.giantswarm.application.upstream-chart-version: "1.25.2"
+  io.giantswarm.application.upstream-chart-url: https://github.com/aws/aws-node-termination-handler
+  io.giantswarm.application.restrictions.cluster-singleton: "true"
+  io.giantswarm.application.restrictions.compatible-providers: "aws"

--- a/helm/aws-node-termination-handler/Chart.yaml
+++ b/helm/aws-node-termination-handler/Chart.yaml
@@ -10,7 +10,6 @@ sources:
 restrictions:
   compatibleProviders: ["aws"]
 annotations:
-  application.giantswarm.io/team: "phoenix"
   io.giantswarm.application.audience: giantswarm
   io.giantswarm.application.managed: "true"
   io.giantswarm.application.team: phoenix

--- a/helm/aws-node-termination-handler/templates/_helpers.tpl
+++ b/helm/aws-node-termination-handler/templates/_helpers.tpl
@@ -50,7 +50,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/part-of: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 helm.sh/chart: {{ include "aws-node-termination-handler.chart" . }}
 {{- with .Values.customLabels }}
 {{ toYaml . }}


### PR DESCRIPTION
Add io.giantswarm.application.audience: giantswarm annotation and migrate chart metadata to io.giantswarm.application.* format.

Backstage is becoming the primary entry point for customers to discover apps. This app is used internally by Giant Swarm and is not intended to be customer-facing.

Relates to giantswarm/giantswarm#35731